### PR TITLE
Keep a reference count on the native objects

### DIFF
--- a/library/jni/com_litl_leveldb_DB.cc
+++ b/library/jni/com_litl_leveldb_DB.cc
@@ -10,7 +10,7 @@
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 
-static jint
+static jlong
 nativeOpen(JNIEnv* env,
            jclass clazz,
            jstring dbpath)
@@ -31,13 +31,13 @@ nativeOpen(JNIEnv* env,
         LOGI("Opened database");
     }
 
-    return reinterpret_cast<jint>(db);
+    return reinterpret_cast<jlong>(db);
 }
 
 static void
 nativeClose(JNIEnv* env,
             jclass clazz,
-            jint dbPtr)
+            jlong dbPtr)
 {
     leveldb::DB* db = reinterpret_cast<leveldb::DB*>(dbPtr);
     if (db) {
@@ -50,8 +50,8 @@ nativeClose(JNIEnv* env,
 static jbyteArray
 nativeGet(JNIEnv * env,
           jclass clazz,
-          jint dbPtr,
-          jint snapshotPtr,
+          jlong dbPtr,
+          jlong snapshotPtr,
           jbyteArray keyObj)
 {
     leveldb::DB* db = reinterpret_cast<leveldb::DB*>(dbPtr);
@@ -83,7 +83,7 @@ nativeGet(JNIEnv * env,
 static void
 nativePut(JNIEnv *env,
           jclass clazz,
-          jint dbPtr,
+          jlong dbPtr,
           jbyteArray keyObj,
           jbyteArray valObj)
 {
@@ -110,7 +110,7 @@ nativePut(JNIEnv *env,
 static void
 nativeDelete(JNIEnv *env,
              jclass clazz,
-             jint dbPtr,
+             jlong dbPtr,
              jbyteArray keyObj)
 {
     leveldb::DB* db = reinterpret_cast<leveldb::DB*>(dbPtr);
@@ -129,8 +129,8 @@ nativeDelete(JNIEnv *env,
 static void
 nativeWrite(JNIEnv *env,
             jclass clazz,
-            jint dbPtr,
-            jint batchPtr)
+            jlong dbPtr,
+            jlong batchPtr)
 {
     leveldb::DB* db = reinterpret_cast<leveldb::DB*>(dbPtr);
 
@@ -141,35 +141,35 @@ nativeWrite(JNIEnv *env,
     }
 }
 
-static jint
+static jlong
 nativeIterator(JNIEnv* env,
                jclass clazz,
-               jint dbPtr,
-               jint snapshotPtr)
+               jlong dbPtr,
+               jlong snapshotPtr)
 {
     leveldb::DB* db = reinterpret_cast<leveldb::DB*>(dbPtr);
     leveldb::ReadOptions options = leveldb::ReadOptions();
     options.snapshot = reinterpret_cast<leveldb::Snapshot*>(snapshotPtr);
 
     leveldb::Iterator *iter = db->NewIterator(options);
-    return reinterpret_cast<jint>(iter);
+    return reinterpret_cast<jlong>(iter);
 }
 
-static jint
+static jlong
 nativeGetSnapshot(JNIEnv *env,
                   jclass clazz,
-                  jint dbPtr)
+                  jlong dbPtr)
 {
     leveldb::DB* db = reinterpret_cast<leveldb::DB*>(dbPtr);
     const leveldb::Snapshot* snapshot = db->GetSnapshot();
-    return reinterpret_cast<jint>(snapshot);
+    return reinterpret_cast<jlong>(snapshot);
 }
 
 static void
 nativeReleaseSnapshot(JNIEnv *env,
                       jclass clazz,
-                      jint dbPtr,
-                      jint snapshotPtr)
+                      jlong dbPtr,
+                      jlong snapshotPtr)
 {
     leveldb::DB* db = reinterpret_cast<leveldb::DB*>(dbPtr);
     const leveldb::Snapshot *snapshot = reinterpret_cast<leveldb::Snapshot*>(snapshotPtr);
@@ -192,15 +192,15 @@ nativeDestroy(JNIEnv *env,
 
 static JNINativeMethod sMethods[] =
 {
-        { "nativeOpen", "(Ljava/lang/String;)I", (void*) nativeOpen },
-        { "nativeClose", "(I)V", (void*) nativeClose },
-        { "nativeGet", "(II[B)[B", (void*) nativeGet },
-        { "nativePut", "(I[B[B)V", (void*) nativePut },
-        { "nativeDelete", "(I[B)V", (void*) nativeDelete },
-        { "nativeWrite", "(II)V", (void*) nativeWrite },
-        { "nativeIterator", "(II)I", (void*) nativeIterator },
-        { "nativeGetSnapshot", "(I)I", (void*) nativeGetSnapshot },
-        { "nativeReleaseSnapshot", "(II)V", (void*) nativeReleaseSnapshot },
+        { "nativeOpen", "(Ljava/lang/String;)J", (void*) nativeOpen },
+        { "nativeClose", "(J)V", (void*) nativeClose },
+        { "nativeGet", "(JJ[B)[B", (void*) nativeGet },
+        { "nativePut", "(J[B[B)V", (void*) nativePut },
+        { "nativeDelete", "(J[B)V", (void*) nativeDelete },
+        { "nativeWrite", "(JJ)V", (void*) nativeWrite },
+        { "nativeIterator", "(JJ)J", (void*) nativeIterator },
+        { "nativeGetSnapshot", "(J)J", (void*) nativeGetSnapshot },
+        { "nativeReleaseSnapshot", "(JJ)V", (void*) nativeReleaseSnapshot },
         { "nativeDestroy", "(Ljava/lang/String;)V", (void*) nativeDestroy }
 };
 

--- a/library/jni/com_litl_leveldb_Iterator.cc
+++ b/library/jni/com_litl_leveldb_Iterator.cc
@@ -8,7 +8,7 @@
 static void
 nativeDestroy(JNIEnv* env,
               jclass clazz,
-              jint ptr)
+              jlong ptr)
 {
     leveldb::Iterator* iter = reinterpret_cast<leveldb::Iterator*>(ptr);
 
@@ -18,7 +18,7 @@ nativeDestroy(JNIEnv* env,
 static void
 nativeSeekToFirst(JNIEnv* env,
                   jclass clazz,
-                  jint iterPtr)
+                  jlong iterPtr)
 {
     leveldb::Iterator* iter = reinterpret_cast<leveldb::Iterator*>(iterPtr);
     iter->SeekToFirst();
@@ -27,7 +27,7 @@ nativeSeekToFirst(JNIEnv* env,
 static void
 nativeSeek(JNIEnv* env,
            jclass clazz,
-           jint iterPtr,
+           jlong iterPtr,
            jbyteArray keyObj)
 {
     leveldb::Iterator* iter = reinterpret_cast<leveldb::Iterator*>(iterPtr);
@@ -42,7 +42,7 @@ nativeSeek(JNIEnv* env,
 static jboolean
 nativeValid(JNIEnv* env,
             jclass clazz,
-            jint iterPtr)
+            jlong iterPtr)
 {
     leveldb::Iterator* iter = reinterpret_cast<leveldb::Iterator*>(iterPtr);
     return iter->Valid();
@@ -51,7 +51,7 @@ nativeValid(JNIEnv* env,
 static void
 nativeNext(JNIEnv* env,
            jclass clazz,
-           jint iterPtr)
+           jlong iterPtr)
 {
     leveldb::Iterator* iter = reinterpret_cast<leveldb::Iterator*>(iterPtr);
     iter->Next();
@@ -60,7 +60,7 @@ nativeNext(JNIEnv* env,
 static void
 nativePrev(JNIEnv* env,
            jclass clazz,
-           jint iterPtr)
+           jlong iterPtr)
 {
     leveldb::Iterator* iter = reinterpret_cast<leveldb::Iterator*>(iterPtr);
     iter->Prev();
@@ -69,7 +69,7 @@ nativePrev(JNIEnv* env,
 static jbyteArray
 nativeKey(JNIEnv* env,
           jclass clazz,
-          jint iterPtr)
+          jlong iterPtr)
 {
     leveldb::Iterator* iter = reinterpret_cast<leveldb::Iterator*>(iterPtr);
     leveldb::Slice key = iter->key();
@@ -83,7 +83,7 @@ nativeKey(JNIEnv* env,
 static jbyteArray
 nativeValue(JNIEnv* env,
             jclass clazz,
-            jint iterPtr)
+            jlong iterPtr)
 {
     leveldb::Iterator* iter = reinterpret_cast<leveldb::Iterator*>(iterPtr);
     leveldb::Slice value = iter->value();
@@ -96,14 +96,14 @@ nativeValue(JNIEnv* env,
 
 static JNINativeMethod sMethods[] =
 {
-        { "nativeDestroy", "(I)V", (void*) nativeDestroy },
-        { "nativeSeekToFirst", "(I)V", (void*) nativeSeekToFirst },
-        { "nativeSeek", "(I[B)V", (void*) nativeSeek },
-        { "nativeValid", "(I)Z", (void*) nativeValid },
-        { "nativeNext", "(I)V", (void*) nativeNext },
-        { "nativePrev", "(I)V", (void*) nativePrev },
-        { "nativeKey", "(I)[B", (void*) nativeKey },
-        { "nativeValue", "(I)[B", (void*) nativeValue }
+        { "nativeDestroy", "(J)V", (void*) nativeDestroy },
+        { "nativeSeekToFirst", "(J)V", (void*) nativeSeekToFirst },
+        { "nativeSeek", "(J[B)V", (void*) nativeSeek },
+        { "nativeValid", "(J)Z", (void*) nativeValid },
+        { "nativeNext", "(J)V", (void*) nativeNext },
+        { "nativePrev", "(J)V", (void*) nativePrev },
+        { "nativeKey", "(J)[B", (void*) nativeKey },
+        { "nativeValue", "(J)[B", (void*) nativeValue }
 };
 
 int

--- a/library/jni/com_litl_leveldb_WriteBatch.cc
+++ b/library/jni/com_litl_leveldb_WriteBatch.cc
@@ -13,7 +13,7 @@ static jmethodID gByteBuffer_positionMethodID;
 static jmethodID gByteBuffer_limitMethodID;
 static jmethodID gByteBuffer_arrayMethodID;
 
-static jint
+static jlong
 nativeCreate(JNIEnv* env,
              jclass clazz)
 {
@@ -33,13 +33,13 @@ nativeCreate(JNIEnv* env,
     }
 
     leveldb::WriteBatch* batch = new leveldb::WriteBatch();
-    return reinterpret_cast<jint>(batch);
+    return reinterpret_cast<jlong>(batch);
 }
 
 static void
 nativeDestroy(JNIEnv* env,
               jclass clazz,
-              jint ptr)
+              jlong ptr)
 {
     leveldb::WriteBatch* batch = reinterpret_cast<leveldb::WriteBatch*>(ptr);
 
@@ -49,7 +49,7 @@ nativeDestroy(JNIEnv* env,
 static void
 nativeDelete(JNIEnv* env,
              jclass clazz,
-             jint ptr,
+             jlong ptr,
              jobject buffer)
 {
     leveldb::WriteBatch* batch = reinterpret_cast<leveldb::WriteBatch*>(ptr);
@@ -71,7 +71,7 @@ nativeDelete(JNIEnv* env,
 static void
 nativePut(JNIEnv* env,
           jclass clazz,
-          jint ptr,
+          jlong ptr,
           jobject keyObj,
           jobject valObj)
 {
@@ -117,7 +117,7 @@ nativePut(JNIEnv* env,
 static void
 nativeClear(JNIEnv* env,
             jclass clazz,
-            jint ptr)
+            jlong ptr)
 {
     leveldb::WriteBatch* batch = reinterpret_cast<leveldb::WriteBatch*>(ptr);
     batch->Clear();
@@ -125,11 +125,11 @@ nativeClear(JNIEnv* env,
 
 static JNINativeMethod sMethods[] =
 {
-        { "nativeCreate", "()I", (void*) nativeCreate },
-        { "nativeDestroy", "(I)V", (void*) nativeDestroy },
-        { "nativeDelete", "(ILjava/nio/ByteBuffer;)V", (void*) nativeDelete },
-        { "nativePut", "(ILjava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)V", (void*) nativePut },
-        { "nativeClear", "(I)V", (void*) nativeClear }
+        { "nativeCreate", "()J", (void*) nativeCreate },
+        { "nativeDestroy", "(J)V", (void*) nativeDestroy },
+        { "nativeDelete", "(JLjava/nio/ByteBuffer;)V", (void*) nativeDelete },
+        { "nativePut", "(JLjava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)V", (void*) nativePut },
+        { "nativeClear", "(J)V", (void*) nativeClear }
 };
 
 int

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -15,6 +15,14 @@
         <version>0.0.1</version>
     </parent>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
+            <version>4.1.1.4</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <sourceDirectory>src</sourceDirectory>
         <plugins>

--- a/library/src/com/litl/leveldb/DB.java
+++ b/library/src/com/litl/leveldb/DB.java
@@ -3,7 +3,7 @@ package com.litl.leveldb;
 import java.io.File;
 
 public class DB extends NativeObject {
-    public abstract class Snapshot extends NativeObject {
+    public abstract static class Snapshot extends NativeObject {
         Snapshot(long ptr) {
             super(ptr);
         }

--- a/library/src/com/litl/leveldb/DB.java
+++ b/library/src/com/litl/leveldb/DB.java
@@ -4,13 +4,13 @@ import java.io.File;
 
 public class DB extends NativeObject {
     public static class Snapshot {
-        private int mPtr;
+        private long mPtr;
 
-        Snapshot(int ptr) {
+        Snapshot(long ptr) {
             mPtr = ptr;
         }
 
-        int getPtr() {
+        long getPtr() {
             return mPtr;
         }
     }
@@ -31,7 +31,7 @@ public class DB extends NativeObject {
     }
 
     @Override
-    public void closeNativeObject(int ptr) {
+    public void closeNativeObject(long ptr) {
         nativeClose(ptr);
     }
 
@@ -105,25 +105,25 @@ public class DB extends NativeObject {
         nativeDestroy(path.getAbsolutePath());
     }
 
-    private static native int nativeOpen(String dbpath);
+    private static native long nativeOpen(String dbpath);
 
-    private static native void nativeClose(int dbPtr);
+    private static native void nativeClose(long dbPtr);
 
-    private static native void nativePut(int dbPtr, byte[] key, byte[] value);
+    private static native void nativePut(long dbPtr, byte[] key, byte[] value);
 
-    private static native byte[] nativeGet(int dbPtr, int snapshotPtr, byte[] key);
+    private static native byte[] nativeGet(long dbPtr, long snapshotPtr, byte[] key);
 
-    private static native void nativeDelete(int dbPtr, byte[] key);
+    private static native void nativeDelete(long dbPtr, byte[] key);
 
-    private static native void nativeWrite(int dbPtr, int batchPtr);
+    private static native void nativeWrite(long dbPtr, long batchPtr);
 
     private static native void nativeDestroy(String dbpath);
 
-    private static native int nativeIterator(int dbPtr, int snapshotPtr);
+    private static native long nativeIterator(long dbPtr, long snapshotPtr);
 
-    private static native int nativeGetSnapshot(int dbPtr);
+    private static native long nativeGetSnapshot(long dbPtr);
 
-    private static native void nativeReleaseSnapshot(int dbPtr, int snapshotPtr);
+    private static native void nativeReleaseSnapshot(long dbPtr, long snapshotPtr);
 
     public static native String stringFromJNI();
 

--- a/library/src/com/litl/leveldb/DB.java
+++ b/library/src/com/litl/leveldb/DB.java
@@ -10,6 +10,7 @@ public class DB extends NativeObject {
     }
 
     private final File mPath;
+    private boolean mDestroyOnClose = false;
 
     public DB(File path) {
         super();
@@ -27,6 +28,10 @@ public class DB extends NativeObject {
     @Override
     protected void closeNativeObject(long ptr) {
         nativeClose(ptr);
+
+        if (mDestroyOnClose) {
+            destroy(mPath);
+        }
     }
 
     public void put(byte[] key, byte[] value) {
@@ -107,6 +112,13 @@ public class DB extends NativeObject {
                 DB.this.unref();
             }
         };
+    }
+
+    public void destroy() {
+        mDestroyOnClose = true;
+        if (getPtr() == 0) {
+            destroy(mPath);
+        }
     }
 
     public static void destroy(File path) {

--- a/library/src/com/litl/leveldb/Iterator.java
+++ b/library/src/com/litl/leveldb/Iterator.java
@@ -1,12 +1,12 @@
 package com.litl.leveldb;
 
 public class Iterator extends NativeObject {
-    Iterator(int iterPtr) {
+    Iterator(long iterPtr) {
         super(iterPtr);
     }
 
     @Override
-    public void closeNativeObject(int ptr) {
+    public void closeNativeObject(long ptr) {
         nativeDestroy(ptr);
     }
 
@@ -48,19 +48,19 @@ public class Iterator extends NativeObject {
         return nativeValue(mPtr);
     }
 
-    private static native void nativeDestroy(int ptr);
+    private static native void nativeDestroy(long ptr);
 
-    private static native void nativeSeekToFirst(int ptr);
+    private static native void nativeSeekToFirst(long ptr);
 
-    private static native void nativeSeek(int ptr, byte[] key);
+    private static native void nativeSeek(long ptr, byte[] key);
 
-    private static native boolean nativeValid(int ptr);
+    private static native boolean nativeValid(long ptr);
 
-    private static native void nativeNext(int ptr);
+    private static native void nativeNext(long ptr);
 
-    private static native void nativePrev(int ptr);
+    private static native void nativePrev(long ptr);
 
-    private static native byte[] nativeKey(int dbPtr);
+    private static native byte[] nativeKey(long dbPtr);
 
-    private static native byte[] nativeValue(int dbPtr);
+    private static native byte[] nativeValue(long dbPtr);
 }

--- a/library/src/com/litl/leveldb/Iterator.java
+++ b/library/src/com/litl/leveldb/Iterator.java
@@ -6,7 +6,7 @@ public class Iterator extends NativeObject {
     }
 
     @Override
-    public void closeNativeObject(long ptr) {
+    protected void closeNativeObject(long ptr) {
         nativeDestroy(ptr);
     }
 

--- a/library/src/com/litl/leveldb/NativeObject.java
+++ b/library/src/com/litl/leveldb/NativeObject.java
@@ -3,7 +3,10 @@ package com.litl.leveldb;
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import android.util.Log;
+
 abstract class NativeObject implements Closeable {
+    private static final String TAG = NativeObject.class.getSimpleName();
     protected long mPtr;
     private AtomicInteger mRefCount = new AtomicInteger();
 
@@ -49,5 +52,17 @@ abstract class NativeObject implements Closeable {
     @Override
     public void close() {
         unref();
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        if (mPtr != 0) {
+            Log.w(TAG,
+                    "NativeObject "
+                            + getClass().getSimpleName()
+                            + " was finalized before native resource was closed, did you forget to call close()?");
+        }
+
+        super.finalize();
     }
 }

--- a/library/src/com/litl/leveldb/NativeObject.java
+++ b/library/src/com/litl/leveldb/NativeObject.java
@@ -3,12 +3,12 @@ package com.litl.leveldb;
 import java.io.Closeable;
 
 abstract class NativeObject implements Closeable {
-    protected int mPtr;
+    protected long mPtr;
 
     protected NativeObject() {
     }
 
-    protected NativeObject(int ptr) {
+    protected NativeObject(long ptr) {
         if (ptr == 0) {
             throw new OutOfMemoryError("Failed to allocate native object");
         }
@@ -16,7 +16,7 @@ abstract class NativeObject implements Closeable {
         mPtr = ptr;
     }
 
-    protected int getPtr() {
+    protected long getPtr() {
         return mPtr;
     }
 
@@ -34,5 +34,5 @@ abstract class NativeObject implements Closeable {
         }
     }
 
-    protected abstract void closeNativeObject(int ptr);
+    protected abstract void closeNativeObject(long ptr);
 }

--- a/library/src/com/litl/leveldb/WriteBatch.java
+++ b/library/src/com/litl/leveldb/WriteBatch.java
@@ -8,7 +8,7 @@ public class WriteBatch extends NativeObject {
     }
 
     @Override
-    public void closeNativeObject(int ptr) {
+    public void closeNativeObject(long ptr) {
         nativeDestroy(ptr);
     }
 
@@ -40,11 +40,11 @@ public class WriteBatch extends NativeObject {
 
     private static native int nativeCreate();
 
-    private static native void nativeDestroy(int ptr);
+    private static native void nativeDestroy(long ptr);
 
-    private static native void nativeDelete(int ptr, ByteBuffer key);
+    private static native void nativeDelete(long ptr, ByteBuffer key);
 
-    private static native void nativePut(int ptr, ByteBuffer key, ByteBuffer val);
+    private static native void nativePut(long ptr, ByteBuffer key, ByteBuffer val);
 
-    private static native void nativeClear(int ptr);
+    private static native void nativeClear(long ptr);
 }

--- a/library/src/com/litl/leveldb/WriteBatch.java
+++ b/library/src/com/litl/leveldb/WriteBatch.java
@@ -8,7 +8,7 @@ public class WriteBatch extends NativeObject {
     }
 
     @Override
-    public void closeNativeObject(long ptr) {
+    protected void closeNativeObject(long ptr) {
         nativeDestroy(ptr);
     }
 
@@ -38,7 +38,7 @@ public class WriteBatch extends NativeObject {
         nativeClear(mPtr);
     }
 
-    private static native int nativeCreate();
+    private static native long nativeCreate();
 
     private static native void nativeDestroy(long ptr);
 

--- a/tests/src/com/litl/leveldb/test/DBTests.java
+++ b/tests/src/com/litl/leveldb/test/DBTests.java
@@ -122,7 +122,7 @@ public class DBTests extends AndroidTestCase {
             assertEquals(3, i);
         } finally {
             iter.close();
-            mDb.releaseSnapshot(snapshot);
+            snapshot.close();
         }
 
         assertTrue(Arrays.equals(mDb.get(bytes("hello")), bytes("two")));


### PR DESCRIPTION
When creating a snapshot or an iterator, increase the reference count of
the database or snapshot it's based on. Close the native resource when
it's refcount reaches 0, rather than explicitely closing the wrapper.
