### PR TITLE
Try not to kill build hosts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 task ndkBuild(type: Exec) {
-    commandLine 'ndk-build', '-j', '-C', 'library'
+    commandLine 'ndk-build', '-C', 'library'
 }
 tasks.withType(JavaCompile) {
     compileTask -> compileTask.dependsOn ndkBuild


### PR DESCRIPTION
Remove the -j argument from ndk-build in gradle build file, it meant "allow 
infitie jobs". Build hosts unfortunately have finite resources.
